### PR TITLE
Added custom mac addresses + dhcp renew, longer tcp ack retransmit timeout, improved error handling.

### DIFF
--- a/NinjaBlockEthernet/NinjaBlockEthernet.cpp
+++ b/NinjaBlockEthernet/NinjaBlockEthernet.cpp
@@ -4,6 +4,8 @@
 
 byte _mac[] = { 0xCE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED};
 
+char _packet[PACKET_LEN];
+
 EthernetClient client;
 EthernetClient recvclient;
 
@@ -11,6 +13,25 @@ EthernetClient recvclient;
 
 #define kEthernetBytes 4
 #define RETRANSMISSION_TIME 4000
+
+// Like strcpy, except it takes the string from flash memory instead of the more limited SRAM.
+// See: http://playground.arduino.cc/Learning/Memory 
+size_t strcpyf(char *buffer, const __FlashStringHelper *ifsh) {
+	const char PROGMEM *p = (const char PROGMEM *)ifsh;
+	size_t n = 0;
+	char *b = buffer;
+	
+	unsigned char c = pgm_read_byte(p++);
+	
+	while(c != '\0') {
+		*b++ = c;
+		n++;
+		
+		c = pgm_read_byte(p++);
+	}
+	*b = '\0';
+	return n;
+}
 
 // Lets you specify your own MAC (instead of default one declared within library).
 int NinjaBlockClass::begin(byte *mac)
@@ -21,12 +42,12 @@ int NinjaBlockClass::begin(byte *mac)
 		)
 	{
 		result = 1;
-		Serial.print("IP: ");
+		Serial.print(F("IP: "));
 		for (byte thisByte = 0; thisByte < kEthernetBytes; thisByte++) 
 		{
 			// print the value of each byte of the IP address:
 			Serial.print(Ethernet.localIP()[thisByte], DEC);
-			Serial.print(".");
+			Serial.print('.');
 		}
 		Serial.println();
 	}
@@ -43,108 +64,201 @@ int NinjaBlockClass::begin()
 	return begin(_mac);
 }
 
-void NinjaBlockClass::httppost(char *postData)
+//Most Arduinos, 2-byte int range -32,768 to 32,767 (max 6 chars)
+//Arduino Duo, 4-byte range -2,147,483,648 to 2,147,483,647 (max 11 chars)
+const byte kNumLength = (sizeof(int) * 3)+1;	// +1 is to allow for null terminator.
+char strNumber[kNumLength];
+//return reference to strNumber
+inline char *int2str(int num) {
+	return itoa(num, strNumber, 10); // base 10
+}
+
+void NinjaBlockClass::httppost(bool isInt, int intData, char *charData)
 {	
-	Serial.print("_");
+	Serial.print('_');
     if (!client.connected()) {
         client.flush();
         client.stop();
         client.connect(host,port);
+		Serial.print('\'');
     }
 	if (client.connected()) {
-		sendHeaders(true,client);
-		client.print("Content-Length: ");
-		client.println(strlen(postData));
-		client.println();
-		client.println(postData);	
-		Serial.print("Sent=");
-		Serial.println(postData);		
+		char* p_packet = prepareHeaders(true, _packet);
+		strcpyf(p_packet, F("Content-Length: ")); 		// 16 chars
+		p_packet += 16;
+		int2str(calculateNinjaMessageLength(isInt, intData, charData));
+		strcpy(p_packet, strNumber); 						
+		p_packet += strlen(strNumber);
+		strcpyf(p_packet, F("\r\n\r\n"));				// 4 chars.
+		p_packet += 4;
+		
+		copyNinjaMessage(isInt, intData, charData, p_packet);
+		client.println(_packet);
+		Serial.print(F("Sent="));
+		Serial.println(p_packet);
 		client.flush();
 		client.stop();
 	} else {
-		Serial.println("Send Failed");
+		Serial.println(F("Send Failed"));
 	}
 	return;
 }
 
-void NinjaBlockClass::sendHeaders(bool isPOST, EthernetClient hclient) {
-	char strData[DATA_LEN];
-	if (isPOST)  
-		strcpy(strData,"POST");
-	else 
-		strcpy(strData,"GET");
-	strcat(strData," /rest/v0/block/");
-	strcat(strData, nodeID);
-	if (isPOST)  
-		strcat(strData,"/data");
-	else 
-		strcat(strData, "/commands");
-	strcat(strData, " HTTP/1.1\r\n");
-	hclient.print(strData);
-	strcpy(strData,"Host: "); 
-	strcat(strData ,host);
-	strcat(strData, "\r\n");
-	hclient.print(strData);
-	hclient.print("User-Agent: Ninja Arduino 1.1\r\n");
-	if(isPOST) // Content-Type only applicable for POSTs, not GETs.
-		hclient.print("Content-Type: application/json\r\n")
-	hclient.print("Accept: application/json\r\n");
-	strcpy(strData,"X-Ninja-Token: ");
-	strcat(strData, token);
-	strcat(strData,"\r\n");
-	hclient.print(strData);
+// Prepares all the headers in the packet buffer.
+// Returns: Pointer for start of body.
+char* NinjaBlockClass::prepareHeaders(bool isPOST, char* packet) {
+	char* p_packet = packet;
+	if(isPOST) {
+		strcpyf(p_packet, F("POST"));										// 4 chars.
+		p_packet += 4;
+	}
+	else { //isGET
+		strcpyf(p_packet, F("GET"));										// 3 chars.
+		p_packet += 3;
+	}
+	strcpyf(p_packet, F(" /rest/v0/block/"));								// 16 chars.
+	p_packet += 16;
+	strcpy(p_packet, nodeID);
+	p_packet += strlen(nodeID);
+	if(isPOST) {
+		strcpyf(p_packet, F("/data"));										// 5 chars.
+		p_packet += 5;
+	}
+	else {
+		strcpyf(p_packet, F("/commands"));									// 9 chars.
+		p_packet += 9;
+	}
+	strcpyf(p_packet, F(" HTTP/1.1\r\n"));									// 11 chars.
+	p_packet += 11;
+	strcpyf(p_packet, F("Host: "));											// 6 chars.
+	p_packet += 6;
+	strcpy(p_packet, host);													// strlen(host) chars.
+	p_packet += strlen(host);
+	strcpyf(p_packet, F("\r\nUser-Agent: Ninja Arduino 1.2\r\n"));			// 33 chars.
+	p_packet += 33;
+	if(isPOST) { // Content-Type only applicable for POSTS, not GETs.
+		strcpyf(p_packet, F("Content-Type: application/json\r\n"));			// 32 chars.
+		p_packet += 32;
+	}
+	strcpyf(p_packet, F("Accept: application/json\r\nX-Ninja-Token: "));	// 41 chars.
+	p_packet += 41;
+	strcpy(p_packet, token);												// strlen(token) chars.
+	p_packet += strlen(token);
+	strcpyf(p_packet, F("\r\n"));											// 2 chars.
+	p_packet += 2;
+	return p_packet;
 }
+	
 
 void NinjaBlockClass::send(char *data)
 {
-	ninjaMessage(false, 0, data);
+	httppost(false, 0, data);
+	//ninjaMessage(false, 0, data);
 }
 
 void NinjaBlockClass::send(int data)
 {
-	ninjaMessage(true, data, 0);
+	httppost(true, data, 0);
+//	ninjaMessage(true, data, 0);
 }
 
-//Most Arduinos, 2-byte int range -32,768 to 32,767 (max 6 chars)
-//Arduino Duo, 4-byte range -2,147,483,648 to 2,147,483,647 (max 11 chars)
-const char kNumLength = sizeof(int) * 3;
-char strNumber[kNumLength];
-//return reference to strNumber
-char *int2str(int num) {
-	return itoa(num, strNumber, 10); // base 10
-}
-char strSend[DATA_SIZE];
-void addStringAndUnderscore(char * str) {
-	strcat(strSend, str);
-	strcat(strSend, "_");
-}
-
-void NinjaBlockClass::ninjaMessage(bool isInt, int intData, char *charData) {
+// Previously would construct ninjaMessage in temp array to be then sent by httppost.
+// Wastes memory, so now copies it into the end of the array after httppost has constructed
+//  the header. Downside to this approach is Content-Length has to be calculated separately.
+void NinjaBlockClass::copyNinjaMessage(bool isInt, int intData, char *charData, char *dst) {
 	if (guid != NULL) {
-		strcpy(strSend,"{\"GUID\": \"");
-		addStringAndUnderscore(nodeID);
-		addStringAndUnderscore(guid);
-		addStringAndUnderscore(int2str(vendorID));
-		strcat(strSend, int2str(deviceID));
-		strcat(strSend, "\",\"G\": \"");
-		strcat(strSend, guid);
-		strcat(strSend, "\",\"V\": ");
-		strcat(strSend, int2str(vendorID));
-		strcat(strSend,",\"D\": ");
-		strcat(strSend, int2str(deviceID));
-		strcat(strSend, ",\"DA\": ");
+		// strcat is too slow to find end of string O(n) so I keep track of pointer myself.
+		char* p_packet = dst;
+		
+		// GUID.
+		strcpyf(p_packet, F("{\"GUID\": \""));				// 10 chars.
+		p_packet += 10; 
+		strcpy(p_packet, nodeID);						// len(nodeID)
+		p_packet += strlen(nodeID);
+		*p_packet = '_';								// 1 char.
+		p_packet += 1;
+		strcpy(p_packet, guid);							// len(guid)
+		p_packet += strlen(guid);
+		*p_packet = '_';								// 1 char.
+		p_packet += 1;
+		strcpy(p_packet, int2str(vendorID));			// len(int2str(vendorID)
+		p_packet += strlen(p_packet);
+		*p_packet = '_';								// 1 char.
+		p_packet += 1;
+		strcpy(p_packet, int2str(deviceID));			// len(int2str(deviceID)) chars.
+		p_packet += strlen(int2str(deviceID));
+		
+		// G
+		strcpyf(p_packet, F("\",\"G\": \""));				// 8 chars.
+		p_packet += 8;
+		strcpy(p_packet, guid);							// len(guid) chars.
+		p_packet += strlen(guid);
+		
+		// V
+		strcpyf(p_packet, F("\",\"V\": "));					// 7 chars.
+		p_packet += 7;
+		strcpy(p_packet, int2str(vendorID));			// len(int2str(vendorID)) chars.
+		p_packet += strlen(p_packet);
+		
+		// D
+		strcpyf(p_packet, F(",\"D\": "));					// 6 chars.
+		p_packet += 6;
+		strcpy(p_packet, int2str(deviceID));			// len(int2str(deviceID)) chars.
+		p_packet += strlen(p_packet);
+		
+		// DA
+		strcpyf(p_packet, F(",\"DA\": "));					// 7 chars.
+		p_packet += 7;
 		if (isInt) {
-			strcat(strSend, int2str(intData));
+			strcpy(p_packet, int2str(intData));			// len(int2str(intData)) chars.
+			p_packet += strlen(p_packet);
 		} else {
-			strcat(strSend, "\"");
-			strcat(strSend, charData);
-			strcat(strSend, "\"");
+			*p_packet = '\"';							// 1 char.
+			p_packet += 1;
+			strcpy(p_packet, charData);					// len(charData) chars.
+			p_packet += strlen(charData);
+			*p_packet = '\"';							// 1 char.
+			p_packet += 1;
 		}
-		strcat(strSend, "}");
-		httppost(strSend);
+		*p_packet = '}';								// 1 char.
+		p_packet += 1;
+		*p_packet = '\0';								// Don't forget to null terminate!
 	}
 }
 
+// There is a field in the header called "Content-Length", which forces us to calculate
+//  the data's length before copying it into the char array.
+// Previously this was handled by fragmenting the TCP packet into two parts: header and data.
+// The fragmentation adds work to other parts of the system, and makes it trickier to debug in
+//  a packet sniffer, so instead I am calculating the length of the POST's data separately.
+// This approach is a little bit more processing than preparing the data ahead of time into a
+//  temporary char array, but it saves the additional memory of that char array.
+int NinjaBlockClass::calculateNinjaMessageLength(bool isInt, int intData, char *charData)
+{
+	// I'll let the compiler optimise this into fewer calls than first appears.
+	int sizeCount = 0;
+	sizeCount += 10;							// '{"GUID": "'
+	sizeCount += strlen(nodeID) + 1;			// nodeID + '_'
+	sizeCount += strlen(guid) + 1;				// guid + '_'
+	sizeCount += strlen(int2str(vendorID)) + 1;	// int2str(vendorID) + '_'
+	sizeCount += strlen(int2str(deviceID));		// int2str(deviceID)
+	sizeCount += 8;								// '","G": "'
+	sizeCount += strlen(guid);					// guid
+	sizeCount += 7;								// '","V": '
+	sizeCount += strlen(int2str(vendorID));		// int2str(vendorID)
+	sizeCount += 6;								// ',"D": '
+	sizeCount += strlen(int2str(deviceID));		// int2str(deviceID);
+	sizeCount += 7;								// ',"DA": '
+	if(isInt) {
+		sizeCount += strlen(int2str(intData));	// int2str(intData);
+	} else {
+		sizeCount += 1;							// '"'
+		sizeCount += strlen(charData);			// charData
+		sizeCount += 1;							// '"'
+	}
+	sizeCount += 1;								// '}'
+	return sizeCount;
+}
 
 const char kStrHeaderEnd[] = {'\r', '\n', '\r', '\n'};
 const byte kHeaderLength = sizeof(kStrHeaderEnd);
@@ -165,17 +279,22 @@ bool NinjaBlockClass::receive(void) {
 	if(!recvclient.connected())
 	{
 		// connect if not connected
-		Serial.print(".");
+		Serial.print(',');
 		recvclient.stop();
 		if(recvclient.connect(host,port)==1)
 		{
-			sendHeaders(false, recvclient);
-			recvclient.println();
+			char* p_packet = prepareHeaders(false, _packet);
+			strcpyf(p_packet, F("\r\n"));
+			p_packet += 2;
+			recvclient.println(_packet);
 		}
 	}
 	if (recvclient.connected())
 	{
 		gotData = receiveConnected();
+	}
+	else {
+		Serial.println(F("RX: Can't connect."));
 	}
 	return gotData;
 }
@@ -219,31 +338,31 @@ bool NinjaBlockClass::receiveConnected(void) {
 			bytesAvailable -= bytesRead;
 			bytesRead = 0;
 
-			if (bytesAvailable > DATA_SIZE) {
+			if (bytesAvailable > PACKET_LEN) {
 				// Error condition. Potential hang point (infinite loop).
 				// Flush and stop the client so the connection can then restart.
 				recvclient.flush();
 				recvclient.stop();
-				Serial.print("ERR: DATA_SIZE");
+				Serial.print(F("ERR: DATA_SIZE"));
 				return false;
 			}
 
-			char data[DATA_SIZE];
+//			char data[DATA_SIZE];		// 
 			//read data into array eg. {"DEVICE":[{"G":"0","V":0,"D":1000,"DA":"FFFFFF"}]}
 			for (bytesRead=0; bytesRead<bytesAvailable; bytesRead++) {
-				data[bytesRead] = recvclient.read();
-				//Serial.print(data[bytesRead]);
+				_packet[bytesRead] = recvclient.read();
+				//Serial.print(_packet[bytesRead]);
 			}
-			data[bytesRead] = '\0'; //terminate data as string
+			_packet[bytesRead] = '\0'; //terminate _packet as string
 			bytesRead = 0;
 			char *strVal;
-			strVal = valueString("G\":\"", data, bytesRead, bytesAvailable);
+			strVal = valueString("G\":\"", _packet, bytesRead, bytesAvailable);
 			if (strVal) {
 				strcpy(strGUID, strVal);
-				strVal = valueString("V\":", data, bytesRead, bytesAvailable);
+				strVal = valueString("V\":", _packet, bytesRead, bytesAvailable);
 				if (strVal != NULL) {
 					intVID = atoi(strVal);
-					strVal = valueString("D\":", data, bytesRead, bytesAvailable);
+					strVal = valueString("D\":", _packet, bytesRead, bytesAvailable);
 					if (strVal != NULL) {
 						intDID = atoi(strVal);
 
@@ -255,7 +374,7 @@ bool NinjaBlockClass::receiveConnected(void) {
 					 	// Serial.println(intDID);
 
 						int start = bytesRead;
-						strVal = valueString("DA\":\"", data, bytesRead, bytesAvailable);
+						strVal = valueString("DA\":\"", _packet, bytesRead, bytesAvailable);
 						if (strVal != NULL) {
 							strcpy(strDATA, strVal);
 							IsDATAString = true;
@@ -264,8 +383,8 @@ bool NinjaBlockClass::receiveConnected(void) {
 							// Serial.println(strDATA);
 						}
 						else { // may be an int value
-							bytesRead = start; // reset to where we were before attempting (data is unmodified if NULL was returned)
-							strVal = valueString("DA\":", data, bytesRead, bytesAvailable);
+							bytesRead = start; // reset to where we were before attempting (_packet is unmodified if NULL was returned)
+							strVal = valueString("DA\":", _packet, bytesRead, bytesAvailable);
 							if (strVal) {
 								intDATA = atoi(strVal);
 								IsDATAString = false;
@@ -286,6 +405,7 @@ bool NinjaBlockClass::receiveConnected(void) {
 		delay(100);
 		recvclient.stop();
 		delay(100);
+		Serial.print('$');
 	}
 	return gotData;
 }
@@ -294,7 +414,12 @@ bool NinjaBlockClass::receiveConnected(void) {
 // renewed when the lease expires.
 int NinjaBlockClass::maintain(void)
 {
-	return Ethernet.maintain();
+	int rc = Ethernet.maintain();
+	if(rc != DHCP_CHECK_NONE) {
+		Serial.print('#');
+		Serial.print(rc);
+	}
+	return rc;
 }
 
 NinjaBlockClass NinjaBlock;

--- a/NinjaBlockEthernet/NinjaBlockEthernet.h
+++ b/NinjaBlockEthernet/NinjaBlockEthernet.h
@@ -10,12 +10,12 @@
 #ifndef ninjablockethernet_h
 #define ninjablockethernet_h
 
-#include <SPI.h>
+#include <utility/w5100.h> // Needed to adjust retransmission time.
 #include <Ethernet.h>
 
-#define DATA_SIZE  128
 #define GUID_LEN	36
 #define DATA_LEN	96
+#define PACKET_LEN 448
 
 class EthernetClient;
 
@@ -42,13 +42,15 @@ public:
 	void send(int data);
 	void send(char *data);
 	bool receive(void);
-	void httppost(char *postData);
 	bool decodeJSON();
 	int maintain();
 
 private:
-	void ninjaMessage(bool, int intData, char *charData);
+	void httppost(bool isInt, int intData, char *charData);
+	void copyNinjaMessage(bool isInt, int intData, char *charData, char *dst);
+	int  calculateNinjaMessageLength(bool isInt, int intData, char *charData);
 	void sendHeaders(bool isPOST, EthernetClient hclient);
+	char* prepareHeaders(bool isPOST, char* packet);
 	bool receiveConnected(void);
 };
 

--- a/NinjaBlockEthernet/NinjaBlockEthernet.h
+++ b/NinjaBlockEthernet/NinjaBlockEthernet.h
@@ -38,11 +38,13 @@ public:
 	bool IsDATAString;
 
 	int begin();
+	int begin(byte *mac);
 	void send(int data);
 	void send(char *data);
 	bool receive(void);
 	void httppost(char *postData);
 	bool decodeJSON();
+	int maintain();
 
 private:
 	void ninjaMessage(bool, int intData, char *charData);


### PR DESCRIPTION
Added support for:
- begin(byte *mac) {...} lets you specify your own MAC address [begin() is still supported]
- Fix to not send "Content-Type" in GET requests.
- Close connection if data size error, so it can restart gracefully.
- Added maintain() method that should be called periodically to refresh DHCP settings.
- Retransmission Time (ie time to retransmit if receive no TCP ACK) set to 4s, default too short.
