### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/NinjaBlocksSerial/keywords.txt
+++ b/NinjaBlocksSerial/keywords.txt
@@ -5,7 +5,7 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-NinjaLightObjects KEYWORD1
+NinjaLightObjects	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords